### PR TITLE
Replace eval upload validation with HMAC

### DIFF
--- a/routes/upload.rb
+++ b/routes/upload.rb
@@ -14,7 +14,8 @@ module Sinatra
 
             # Verify
             # Before we do anything, verify the message wasn't tampered with
-            valid = UploadHelper::validate(text)
+            signature = request.env['HTTP_X_SIGNATURE']
+            valid = UploadHelper::validate(text, signature)
 
             if !valid
               status 403


### PR DESCRIPTION
## Summary
- replace eval-based validation in `UploadHelper` with HMAC check
- look up signature from `X-Signature` header when validating uploads
- update unit tests for new HMAC logic

## Testing
- `bundle exec rake test` *(fails: Mongo server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68501a2b02f08330b5376c0cef68e6d9