### PR TITLE
Update test docs for Mongo

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-This project uses Minitest with MongoDB. Before running the test suite you must have a MongoDB server available. By default tests look for a server on `localhost:27017` and use the database `treestats-test`.
+This project uses Minitest with MongoDB. **Tests will fail unless MongoDB is running**, so ensure a server is available before running the suite. By default tests look for a server on `localhost:27017` and use the database `treestats-test`.
 
 ## Starting MongoDB
 
@@ -12,9 +12,21 @@ docker compose up -d mongo
 
 This exposes MongoDB on port `27017`. You can also run your own `mongod` instance locally if you prefer.
 
+For a minimal test setup you can create a short `docker-compose.yml` containing:
+
+```yaml
+services:
+  mongo:
+    image: mongo:5
+    ports:
+      - "27017:27017"
+```
+
+Start it with `docker compose up -d` to bring up a test database.
+
 ## Environment variables
 
-Set `MONGO_URL` if you want the tests to use a custom connection string:
+Set `MONGO_URL` if you want the tests to use a custom connection string; see `config/mongoid.yml` for how this value is consumed:
 
 ```bash
 export MONGO_URL="mongodb://127.0.0.1:27017/treestats-test"


### PR DESCRIPTION
## Summary
- clarify the need for a running MongoDB server
- add a short Docker Compose snippet for a test MongoDB
- mention `MONGO_URL` in `config/mongoid.yml`

## Testing
- `bundle exec rake test` *(fails: Could not find sassc-2.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_6850317fb20883308773b476221ea7aa