### PR TITLE
Update standalone MongoDB restore docs

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -13,7 +13,11 @@
 
 ### Under standalone MongoDB
 
-TODO
+- `mongo treestats-dev --eval "db.dropDatabase()"`
+- `mongorestore --gzip --archive=backup.dokku.mongo-new.20210201 \
+    --host 127.0.0.1 --port 27017 \
+    --username youruser --password yourpass \
+    --authenticationDatabase admin`
 
 ### Under Dockerized MongoDB
 


### PR DESCRIPTION
## Summary
- document steps for restoring using mongorestore in standalone MongoDB

## Testing
- `bundle install --quiet`
- `bundle exec rake test` *(fails: No primary_preferred server is available)*

------
https://chatgpt.com/codex/tasks/task_e_6852ee43cc3883308c6c895a7614fdd2